### PR TITLE
feat(auth): add initial login and signup functionality

### DIFF
--- a/src/features/auth/auth.controller.ts
+++ b/src/features/auth/auth.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { ApiTags } from '@nestjs/swagger';
+import { LoginDto, RegisterDto } from './auth.dto';
+
+@ApiTags('auth')
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('register')
+  async register(@Body() body: RegisterDto) {
+    return this.authService.register(body.email, body.password);
+  }
+
+  @Post('login')
+  async login(@Body() body: LoginDto) {
+    const user = await this.authService.validateUser(body.email, body.password);
+    return this.authService.login(user);
+  }
+}

--- a/src/features/auth/auth.dto.ts
+++ b/src/features/auth/auth.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class RegisterDto {
+  @ApiProperty()
+  @IsEmail()
+  email: string;
+
+  @ApiProperty()
+  @IsString()
+  @MinLength(6)
+  password: string;
+}
+
+export class LoginDto {
+  @ApiProperty()
+  @IsEmail()
+  email: string;
+
+  @ApiProperty()
+  @IsString()
+  password: string;
+}

--- a/src/features/auth/auth.module.ts
+++ b/src/features/auth/auth.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { JwtStrategy } from './jwt.strategy';
+import { PrismaModule } from '../../core/prisma/prisma.module';
+
+@Module({
+  imports: [
+    PrismaModule,
+    PassportModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: '1h' },
+      }),
+    }),
+  ],
+  providers: [AuthService, JwtStrategy],
+  controllers: [AuthController],
+  exports: [AuthService, JwtModule],
+})
+export class AuthModule {}

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from '../../core/prisma/prisma.service';
+import * as bcrypt from 'bcrypt';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private prisma: PrismaService,
+    private jwtService: JwtService,
+  ) {}
+
+  async validateUser(email: string, password: string) {
+    const user = await this.prisma.user.findUnique({ where: { email } });
+    if (user && await bcrypt.compare(password, user.passwordHash)) {
+      const { passwordHash, ...result } = user;
+      return result;
+    }
+    return null;
+  }
+
+  async login(user: any) {
+    const payload = { sub: user.id, email: user.email };
+    return {
+      accessToken: this.jwtService.sign(payload),
+    };
+  }
+
+  async register(email: string, password: string) {
+    const hash = await bcrypt.hash(password, 10);
+    const user = await this.prisma.user.create({
+      data: { email, passwordHash: hash },
+    });
+    const payload = { sub: user.id, email: user.email };
+    return { accessToken: this.jwtService.sign(payload) };
+  }
+}

--- a/src/features/auth/jwt-auth.guard.ts
+++ b/src/features/auth/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/src/features/auth/jwt.strategy.ts
+++ b/src/features/auth/jwt.strategy.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(configService: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: configService.get<string>('JWT_SECRET'),
+    });
+  }
+
+  async validate(payload: any) {
+    return { userId: payload.sub, email: payload.email };
+  }
+}


### PR DESCRIPTION
This pull request introduces a complete authentication feature using JWT for the application. It adds controllers, services, DTOs, guards, and strategies to support user registration, login, and authentication with secure password handling and JWT token issuance. The implementation leverages NestJS modules, Passport.js, and Prisma for database access.

**Authentication Feature Implementation:**

* Added `AuthController` with endpoints for user registration and login, delegating logic to the service layer.
* Introduced `AuthService` to handle user validation, registration (with password hashing), and JWT token generation for login and registration.
* Created `RegisterDto` and `LoginDto` for validating input data using class-validator and Swagger decorators.

**JWT Integration:**

* Added `JwtStrategy` for validating JWT tokens using secrets from configuration, and extracting user information from the token payload.
* Implemented `JwtAuthGuard` to protect routes using the configured JWT strategy.

**Module Setup:**

* Configured `AuthModule` to import necessary modules (`PrismaModule`, `PassportModule`, `JwtModule`), provide authentication services and strategies, and export relevant providers for use in other modules.