### PR TITLE
chore: add initial testing setup

### DIFF
--- a/src/__tests__/auth.controller.spec.ts
+++ b/src/__tests__/auth.controller.spec.ts
@@ -1,0 +1,33 @@
+import { AuthController } from '../features/auth/auth.controller';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+  let mockAuthService: any;
+
+  beforeEach(() => {
+    mockAuthService = {
+      register: jest.fn().mockResolvedValue({ accessToken: 'token' }),
+      validateUser: jest.fn().mockResolvedValue({ id: 'u1', email: 'test@example.com' }),
+      login: jest.fn().mockResolvedValue({ accessToken: 'token' })
+    };
+    controller = new AuthController(mockAuthService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should register a user', async () => {
+    const result = await controller.register({ email: 'test@example.com', password: 'pass' });
+    expect(result).toEqual({ accessToken: 'token' });
+    expect(mockAuthService.register).toHaveBeenCalledWith('test@example.com', 'pass');
+  });
+
+  it('should login a user', async () => {
+    mockAuthService.validateUser.mockResolvedValue({ id: 'u1', email: 'test@example.com' });
+    const result = await controller.login({ email: 'test@example.com', password: 'pass' });
+    expect(result).toEqual({ accessToken: 'token' });
+    expect(mockAuthService.validateUser).toHaveBeenCalledWith('test@example.com', 'pass');
+    expect(mockAuthService.login).toHaveBeenCalledWith({ id: 'u1', email: 'test@example.com' });
+  });
+});

--- a/src/__tests__/auth.module.spec.ts
+++ b/src/__tests__/auth.module.spec.ts
@@ -1,0 +1,7 @@
+import { AuthModule } from '../features/auth/auth.module';
+
+describe('AuthModule', () => {
+  it('should be defined', () => {
+    expect(AuthModule).toBeDefined();
+  });
+});

--- a/src/__tests__/auth.service.spec.ts
+++ b/src/__tests__/auth.service.spec.ts
@@ -1,0 +1,53 @@
+import { AuthService } from '../features/auth/auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let mockPrismaService: any;
+  let mockJwtService: any;
+
+  beforeEach(() => {
+    mockPrismaService = {
+      user: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'u1', email: 'test@example.com', passwordHash: 'hash' }),
+        create: jest.fn().mockResolvedValue({ id: 'u1', email: 'test@example.com', passwordHash: 'hash' })
+      }
+    };
+    mockJwtService = {
+      sign: jest.fn().mockReturnValue('token')
+    };
+    service = new AuthService(mockPrismaService, mockJwtService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should validate user with correct password', async () => {
+    // Mock bcrypt.compare to always return true
+    jest.spyOn(require('bcrypt'), 'compare').mockResolvedValue(true);
+    const result = await service.validateUser('test@example.com', 'pass');
+    expect(mockPrismaService.user.findUnique).toHaveBeenCalledWith({ where: { email: 'test@example.com' } });
+    expect(result).toEqual({ id: 'u1', email: 'test@example.com' });
+  });
+
+  it('should return null for invalid user', async () => {
+    mockPrismaService.user.findUnique.mockResolvedValue(null);
+    const result = await service.validateUser('wrong@example.com', 'pass');
+    expect(result).toBeNull();
+  });
+
+  it('should login user and return token', async () => {
+    const result = await service.login({ id: 'u1', email: 'test@example.com' });
+    expect(mockJwtService.sign).toHaveBeenCalledWith({ sub: 'u1', email: 'test@example.com' });
+    expect(result).toEqual({ accessToken: 'token' });
+  });
+
+  it('should register user and return token', async () => {
+    // Mock bcrypt.hash to return a fixed hash
+    jest.spyOn(require('bcrypt'), 'hash').mockResolvedValue('hash');
+    const result = await service.register('test@example.com', 'pass');
+    expect(mockPrismaService.user.create).toHaveBeenCalledWith({ data: { email: 'test@example.com', passwordHash: 'hash' } });
+    expect(mockJwtService.sign).toHaveBeenCalledWith({ sub: 'u1', email: 'test@example.com' });
+    expect(result).toEqual({ accessToken: 'token' });
+  });
+});

--- a/src/__tests__/genre.prisma.repo.spec.ts
+++ b/src/__tests__/genre.prisma.repo.spec.ts
@@ -1,0 +1,16 @@
+import { GenrePrismaRepository } from '../infra/repos/genre.prisma.repo';
+
+describe('GenrePrismaRepository', () => {
+  let repo: GenrePrismaRepository;
+
+  beforeEach(() => {
+    const mockPrismaService = { /* mock methods as needed */ } as any;
+    repo = new GenrePrismaRepository(mockPrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(repo).toBeDefined();
+  });
+
+  // Add more tests for each method in GenrePrismaRepository
+});

--- a/src/__tests__/genres.controller.spec.ts
+++ b/src/__tests__/genres.controller.spec.ts
@@ -1,0 +1,36 @@
+import { GenresController } from '../features/genres/genres.controller';
+
+describe('GenresController', () => {
+  let controller: GenresController;
+  let mockGenresRepo: any;
+  let mockCache: any;
+
+  beforeEach(() => {
+    mockGenresRepo = {
+      all: jest.fn().mockResolvedValue([{ id: 1, name: 'Action' }]),
+    };
+    mockCache = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn(),
+    };
+    controller = new GenresController(mockGenresRepo, mockCache);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should return all genres', async () => {
+    const result = await controller.list();
+    expect(result).toEqual([{ id: 1, name: 'Action' }]);
+    expect(mockGenresRepo.all).toHaveBeenCalled();
+    expect(mockCache.set).toHaveBeenCalled();
+  });
+
+  it('should return cached genres if present', async () => {
+    mockCache.get.mockResolvedValueOnce([{ id: 2, name: 'Comedy' }]);
+    const result = await controller.list();
+    expect(result).toEqual([{ id: 2, name: 'Comedy' }]);
+    expect(mockGenresRepo.all).not.toHaveBeenCalled(); // should not hit DB
+  });
+});

--- a/src/__tests__/genres.module.spec.ts
+++ b/src/__tests__/genres.module.spec.ts
@@ -1,0 +1,7 @@
+import { GenresModule } from '../features/genres/genres.module';
+
+describe('GenresModule', () => {
+  it('should be defined', () => {
+    expect(GenresModule).toBeDefined();
+  });
+});

--- a/src/__tests__/lists.controller.spec.ts
+++ b/src/__tests__/lists.controller.spec.ts
@@ -1,0 +1,76 @@
+import { ListsController } from '../features/lists/lists.controller';
+
+describe('ListsController', () => {
+  let controller: ListsController;
+  let mockListsService: any;
+
+  beforeEach(() => {
+    mockListsService = {
+      getWatchlist: jest.fn().mockResolvedValue([{ id: 'm1', title: 'Inception' }]),
+      addToWatchlist: jest.fn().mockResolvedValue({ id: 'm1', title: 'Inception' }),
+      removeFromWatchlist: jest.fn().mockResolvedValue({ success: true }),
+
+      getFavorites: jest.fn().mockResolvedValue([{ id: 'm2', title: 'Interstellar' }]),
+      addToFavorites: jest.fn().mockResolvedValue({ id: 'm2', title: 'Interstellar' }),
+      removeFromFavorites: jest.fn().mockResolvedValue({ success: true }),
+    };
+
+    controller = new ListsController(mockListsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('Watchlist', () => {
+    it('should return user watchlist', async () => {
+      const result = await controller.getWatchlist({ user: { userId: 'u1' } });
+      expect(result).toEqual([{ id: 'm1', title: 'Inception' }]);
+      expect(mockListsService.getWatchlist).toHaveBeenCalledWith('u1');
+    });
+
+    it('should add to watchlist', async () => {
+      const result = await controller.addToWatchlist(
+        { user: { userId: 'u1' } },
+        { movieId: 'm1' },
+      );
+      expect(result).toEqual({ id: 'm1', title: 'Inception' });
+      expect(mockListsService.addToWatchlist).toHaveBeenCalledWith('u1', 'm1');
+    });
+
+    it('should remove from watchlist', async () => {
+      const result = await controller.removeFromWatchlist(
+        { user: { userId: 'u1' } },
+        { movieId: 'm1' },
+      );
+      expect(result).toEqual({ success: true });
+      expect(mockListsService.removeFromWatchlist).toHaveBeenCalledWith('u1', 'm1');
+    });
+  });
+
+  describe('Favorites', () => {
+    it('should return user favorites', async () => {
+      const result = await controller.getFavorites({ user: { userId: 'u1' } });
+      expect(result).toEqual([{ id: 'm2', title: 'Interstellar' }]);
+      expect(mockListsService.getFavorites).toHaveBeenCalledWith('u1');
+    });
+
+    it('should add to favorites', async () => {
+      const result = await controller.addToFavorites(
+        { user: { userId: 'u1' } },
+        { movieId: 'm2' },
+      );
+      expect(result).toEqual({ id: 'm2', title: 'Interstellar' });
+      expect(mockListsService.addToFavorites).toHaveBeenCalledWith('u1', 'm2');
+    });
+
+    it('should remove from favorites', async () => {
+      const result = await controller.removeFromFavorites(
+        { user: { userId: 'u1' } },
+        { movieId: 'm2' },
+      );
+      expect(result).toEqual({ success: true });
+      expect(mockListsService.removeFromFavorites).toHaveBeenCalledWith('u1', 'm2');
+    });
+  });
+});

--- a/src/__tests__/lists.module.spec.ts
+++ b/src/__tests__/lists.module.spec.ts
@@ -1,0 +1,7 @@
+import { ListsModule } from '../features/lists/lists.module';
+
+describe('ListsModule', () => {
+  it('should be defined', () => {
+    expect(ListsModule).toBeDefined();
+  });
+});

--- a/src/__tests__/lists.service.spec.ts
+++ b/src/__tests__/lists.service.spec.ts
@@ -1,0 +1,62 @@
+import { ListsService } from '../features/lists/lists.service';
+
+describe('ListsService', () => {
+  let service: ListsService;
+  let mockPrismaService: any;
+
+  beforeEach(() => {
+    mockPrismaService = {
+      watchlist: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'm1', movie: { title: 'Inception' } }]),
+        create: jest.fn().mockResolvedValue({ id: 'm1', movieId: 'm1' }),
+        delete: jest.fn().mockResolvedValue({ success: true })
+      },
+      favorite: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'm2', movie: { title: 'Interstellar' } }]),
+        create: jest.fn().mockResolvedValue({ id: 'm2', movieId: 'm2' }),
+        delete: jest.fn().mockResolvedValue({ success: true })
+      }
+    };
+    service = new ListsService(mockPrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should get user watchlist', async () => {
+    const result = await service.getWatchlist('u1');
+    expect(result).toEqual([{ id: 'm1', movie: { title: 'Inception' } }]);
+    expect(mockPrismaService.watchlist.findMany).toHaveBeenCalledWith({ where: { userId: 'u1' }, include: { movie: true } });
+  });
+
+  it('should add to watchlist', async () => {
+    const result = await service.addToWatchlist('u1', 'm1');
+    expect(result).toEqual({ id: 'm1', movieId: 'm1' });
+    expect(mockPrismaService.watchlist.create).toHaveBeenCalledWith({ data: { userId: 'u1', movieId: 'm1' } });
+  });
+
+  it('should remove from watchlist', async () => {
+    const result = await service.removeFromWatchlist('u1', 'm1');
+    expect(result).toEqual({ success: true });
+    expect(mockPrismaService.watchlist.delete).toHaveBeenCalledWith({ where: { userId_movieId: { userId: 'u1', movieId: 'm1' } } });
+  });
+
+  it('should get user favorites', async () => {
+    const result = await service.getFavorites('u1');
+    expect(result).toEqual([{ id: 'm2', movie: { title: 'Interstellar' } }]);
+    expect(mockPrismaService.favorite.findMany).toHaveBeenCalledWith({ where: { userId: 'u1' }, include: { movie: true } });
+  });
+
+  it('should add to favorites', async () => {
+    const result = await service.addToFavorites('u1', 'm2');
+    expect(result).toEqual({ id: 'm2', movieId: 'm2' });
+    expect(mockPrismaService.favorite.create).toHaveBeenCalledWith({ data: { userId: 'u1', movieId: 'm2' } });
+  });
+
+  it('should remove from favorites', async () => {
+    const result = await service.removeFromFavorites('u1', 'm2');
+    expect(result).toEqual({ success: true });
+    expect(mockPrismaService.favorite.delete).toHaveBeenCalledWith({ where: { userId_movieId: { userId: 'u1', movieId: 'm2' } } });
+  });
+});

--- a/src/__tests__/movie.prisma.repo.spec.ts
+++ b/src/__tests__/movie.prisma.repo.spec.ts
@@ -1,0 +1,16 @@
+import { MoviePrismaRepository } from '../infra/repos/movie.prisma.repo';
+
+describe('MoviePrismaRepository', () => {
+  let repo: MoviePrismaRepository;
+
+  beforeEach(() => {
+    const mockPrismaService = { /* mock methods as needed */ } as any;
+    repo = new MoviePrismaRepository(mockPrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(repo).toBeDefined();
+  });
+
+  // Add more tests for each method in MoviePrismaRepository
+});

--- a/src/__tests__/movies.controller.spec.ts
+++ b/src/__tests__/movies.controller.spec.ts
@@ -1,0 +1,31 @@
+import { MoviesController } from '../features/movies/movies.controller';
+
+describe('MoviesController', () => {
+  let controller: MoviesController;
+  let mockMoviesService: any;
+
+  beforeEach(() => {
+    mockMoviesService = {
+      list: jest.fn().mockResolvedValue([{ id: 'm1', title: 'Inception' }]),
+      detail: jest.fn().mockResolvedValue({ id: 'm1', title: 'Inception' })
+    };
+    controller = new MoviesController(mockMoviesService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should list movies', async () => {
+    const query = { page: 1, limit: 10, sort: 'title', order: 'asc' };
+    const result = await controller.list(query);
+    expect(result).toEqual([{ id: 'm1', title: 'Inception' }]);
+    expect(mockMoviesService.list).toHaveBeenCalledWith(query);
+  });
+
+  it('should get movie detail', async () => {
+    const result = await controller.detail('m1');
+    expect(result).toEqual({ id: 'm1', title: 'Inception' });
+    expect(mockMoviesService.detail).toHaveBeenCalledWith('m1');
+  });
+});

--- a/src/__tests__/movies.service.spec.ts
+++ b/src/__tests__/movies.service.spec.ts
@@ -1,0 +1,97 @@
+import { MoviesService } from '../features/movies/movies.service';
+import { movieListKey, movieDetailKey } from '../common/cache-keys';
+import { toPageResult } from '../common/pagination';
+
+describe('MoviesService', () => {
+  let service: MoviesService;
+  let mockMoviesRepo: any;
+  let mockCache: any;
+
+  beforeEach(() => {
+    mockMoviesRepo = {
+      list: jest.fn().mockResolvedValue({
+        items: [{ id: 'm1', title: 'Inception' }],
+        total: 1,
+      }),
+      findById: jest.fn().mockResolvedValue({ id: 'm1', title: 'Inception' }),
+    };
+
+    mockCache = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(true),
+    };
+
+    service = new MoviesService(mockMoviesRepo, mockCache);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('list', () => {
+    it('should return cached result if exists', async () => {
+      const q = { page: 1, limit: 10, sort: 'title', order: 'asc' };
+      const cachedResult = { items: [{ id: 'mCached', title: 'Cached' }], total: 1 };
+
+      mockCache.get.mockResolvedValueOnce(cachedResult);
+
+      const result = await service.list(q);
+
+      expect(mockCache.get).toHaveBeenCalledWith(movieListKey(q));
+      expect(result).toEqual(cachedResult);
+      expect(mockMoviesRepo.list).not.toHaveBeenCalled();
+    });
+
+    it('should fetch, paginate, cache, and return movies if no cache', async () => {
+      const q = { page: 1, limit: 10, sort: 'title', order: 'asc' };
+
+      const expected = toPageResult(
+        [{ id: 'm1', title: 'Inception' }],
+        1,
+        q.page,
+        q.limit,
+      );
+
+      const result = await service.list(q);
+
+      expect(mockMoviesRepo.list).toHaveBeenCalledWith(q);
+      expect(mockCache.set).toHaveBeenCalledWith(movieListKey(q), expected, 60);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('detail', () => {
+    it('should return cached movie if exists', async () => {
+      const cachedMovie = { id: 'mCached', title: 'Cached Movie' };
+
+      mockCache.get.mockResolvedValueOnce(cachedMovie);
+
+      const result = await service.detail('mCached');
+
+      expect(mockCache.get).toHaveBeenCalledWith(movieDetailKey('mCached'));
+      expect(result).toEqual(cachedMovie);
+      expect(mockMoviesRepo.findById).not.toHaveBeenCalled();
+    });
+
+    it('should fetch, cache, and return movie if not cached', async () => {
+      const result = await service.detail('m1');
+
+      expect(mockMoviesRepo.findById).toHaveBeenCalledWith('m1');
+      expect(mockCache.set).toHaveBeenCalledWith(
+        movieDetailKey('m1'),
+        { id: 'm1', title: 'Inception' },
+        300,
+      );
+      expect(result).toEqual({ id: 'm1', title: 'Inception' });
+    });
+
+    it('should return null if movie not found', async () => {
+      mockMoviesRepo.findById.mockResolvedValueOnce(null);
+
+      const result = await service.detail('m404');
+
+      expect(mockMoviesRepo.findById).toHaveBeenCalledWith('m404');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/__tests__/rating.prisma.repo.spec.ts
+++ b/src/__tests__/rating.prisma.repo.spec.ts
@@ -1,0 +1,16 @@
+import { RatingPrismaRepository } from '../infra/repos/rating.prisma.repo';
+
+describe('RatingPrismaRepository', () => {
+  let repo: RatingPrismaRepository;
+
+  beforeEach(() => {
+    const mockPrismaService = { /* mock methods as needed */ } as any;
+    repo = new RatingPrismaRepository(mockPrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(repo).toBeDefined();
+  });
+
+  // Add more tests for each method in RatingPrismaRepository
+});

--- a/src/__tests__/ratings.controller.spec.ts
+++ b/src/__tests__/ratings.controller.spec.ts
@@ -1,0 +1,30 @@
+import { RatingsController } from '../features/ratings/ratings.controller';
+
+describe('RatingsController', () => {
+  let controller: RatingsController;
+  let mockRatingsService: any;
+
+  beforeEach(() => {
+    mockRatingsService = {
+      rate: jest.fn().mockResolvedValue({ movieId: 'm1', avg_rating: 8, rating_count: 10 }),
+      getMovieRatings: jest.fn().mockResolvedValue({ movieId: 'm1', avg_rating: 8, rating_count: 10, ratings: [{ userId: 'u1', score: 8 }] })
+    };
+    controller = new RatingsController(mockRatingsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should rate a movie', async () => {
+    const result = await controller.rate('m1', { user: { userId: 'u1' } }, { score: 8 });
+    expect(result).toEqual({ movieId: 'm1', avg_rating: 8, rating_count: 10 });
+    expect(mockRatingsService.rate).toHaveBeenCalledWith('u1', 'm1', 8);
+  });
+
+  it('should get ratings for a movie', async () => {
+    const result = await controller.getRatings('m1');
+    expect(result).toEqual({ movieId: 'm1', avg_rating: 8, rating_count: 10, ratings: [{ userId: 'u1', score: 8 }] });
+    expect(mockRatingsService.getMovieRatings).toHaveBeenCalledWith('m1');
+  });
+});

--- a/src/__tests__/ratings.module.spec.ts
+++ b/src/__tests__/ratings.module.spec.ts
@@ -1,0 +1,7 @@
+import { RatingsModule } from '../features/ratings/ratings.module';
+
+describe('RatingsModule', () => {
+  it('should be defined', () => {
+    expect(RatingsModule).toBeDefined();
+  });
+});

--- a/src/__tests__/ratings.service.spec.ts
+++ b/src/__tests__/ratings.service.spec.ts
@@ -1,0 +1,42 @@
+import { RatingsService } from '../features/ratings/ratings.service';
+
+describe('RatingsService', () => {
+  let service: RatingsService;
+  let mockRatingsRepo: any;
+  let mockMoviesRepo: any;
+  let mockCache: any;
+
+  beforeEach(() => {
+    mockRatingsRepo = {
+      upsert: jest.fn().mockResolvedValue(true),
+      findByMovie: jest.fn().mockResolvedValue([{ userId: 'u1', score: 8 }])
+    };
+    mockMoviesRepo = {
+      updateAggregates: jest.fn().mockResolvedValue({ avg: 8, count: 10 }),
+      findAggregates: jest.fn().mockResolvedValue({ avg: 8, count: 10 })
+    };
+    mockCache = {
+      del: jest.fn().mockResolvedValue(true)
+    };
+    service = new RatingsService(mockRatingsRepo, mockMoviesRepo, mockCache);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should rate a movie and update aggregates', async () => {
+    const result = await service.rate('u1', 'm1', 8);
+    expect(mockRatingsRepo.upsert).toHaveBeenCalledWith('u1', 'm1', 8);
+    expect(mockMoviesRepo.updateAggregates).toHaveBeenCalledWith('m1');
+    expect(mockCache.del).toHaveBeenCalled();
+    expect(result).toEqual({ movieId: 'm1', avg_rating: 8, rating_count: 10 });
+  });
+
+  it('should get movie ratings and aggregates', async () => {
+    const result = await service.getMovieRatings('m1');
+    expect(mockRatingsRepo.findByMovie).toHaveBeenCalledWith('m1');
+    expect(mockMoviesRepo.findAggregates).toHaveBeenCalledWith('m1');
+    expect(result).toEqual({ movieId: 'm1', avg_rating: 8, rating_count: 10, ratings: [{ userId: 'u1', score: 8 }] });
+  });
+});

--- a/src/__tests__/sync.controller.spec.ts
+++ b/src/__tests__/sync.controller.spec.ts
@@ -1,0 +1,37 @@
+import { SyncController } from '../features/sync/sync.controller';
+
+describe('SyncController', () => {
+  let controller: SyncController;
+  let mockSyncService: any;
+
+  beforeEach(() => {
+    mockSyncService = {
+      scheduled: jest.fn().mockResolvedValue('done'),
+      syncGenres: jest.fn().mockResolvedValue('genres synced'),
+      syncPopular: jest.fn().mockResolvedValue('popular synced')
+    };
+    controller = new SyncController(mockSyncService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should run scheduled sync', async () => {
+    const result = await controller['syncService'].scheduled();
+    expect(result).toBe('done');
+    expect(mockSyncService.scheduled).toHaveBeenCalled();
+  });
+
+  it('should sync genres', async () => {
+    const result = await controller['syncService'].syncGenres();
+    expect(result).toBe('genres synced');
+    expect(mockSyncService.syncGenres).toHaveBeenCalled();
+  });
+
+  it('should sync popular movies', async () => {
+    const result = await controller['syncService'].syncPopular();
+    expect(result).toBe('popular synced');
+    expect(mockSyncService.syncPopular).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/sync.service.spec.ts
+++ b/src/__tests__/sync.service.spec.ts
@@ -1,0 +1,46 @@
+import { SyncService } from '../features/sync/sync.service';
+
+describe('SyncService', () => {
+  let service: SyncService;
+  let mockTmdbService: any;
+  let mockGenreRepo: any;
+  let mockMovieRepo: any;
+
+  beforeEach(() => {
+    mockTmdbService = {
+      getGenres: jest.fn().mockResolvedValue([{ id: 1, name: 'Action' }]),
+      getPopular: jest.fn().mockResolvedValue({ results: [{ id: 101, title: 'Movie1' }] })
+    };
+    mockGenreRepo = {
+      upsert: jest.fn().mockResolvedValue(true)
+    };
+    mockMovieRepo = {
+      upsertFromTmdb: jest.fn().mockResolvedValue(true)
+    };
+    service = new SyncService(mockTmdbService, mockGenreRepo, mockMovieRepo);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should sync genres from TMDB', async () => {
+    await service.syncGenres();
+    expect(mockTmdbService.getGenres).toHaveBeenCalled();
+    expect(mockGenreRepo.upsert).toHaveBeenCalledWith(1, 'Action');
+  });
+
+  it('should sync popular movies from TMDB', async () => {
+    await service.syncPopular(1);
+    expect(mockTmdbService.getPopular).toHaveBeenCalledWith(1);
+    expect(mockMovieRepo.upsertFromTmdb).toHaveBeenCalledWith({ id: 101, title: 'Movie1' });
+  });
+
+  it('should run scheduled job and call sync methods', async () => {
+    const spyGenres = jest.spyOn(service, 'syncGenres');
+    const spyPopular = jest.spyOn(service, 'syncPopular');
+    await service.scheduled();
+    expect(spyGenres).toHaveBeenCalled();
+    expect(spyPopular).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/tmdb.service.spec.ts
+++ b/src/__tests__/tmdb.service.spec.ts
@@ -1,0 +1,60 @@
+import axios from 'axios';
+import { TmdbService } from '../features/tmdb/tmdb.service';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('TmdbService', () => {
+  let service: TmdbService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const mockInstance = {
+      get: jest.fn(),
+      interceptors: {
+        request: { use: jest.fn(), eject: jest.fn() },
+        response: { use: jest.fn(), eject: jest.fn() },
+      },
+      defaults: { baseURL: 'https://api.themoviedb.org/3' },
+    } as any;
+
+    mockedAxios.create.mockReturnValue(mockInstance);
+
+    service = new TmdbService();
+  });
+
+  it('should get genres from TMDB', async () => {
+    (service as any).client.get.mockResolvedValue({
+      data: { genres: [{ id: 1, name: 'Action' }] },
+    });
+
+    const result = await service.getGenres();
+
+    expect(result).toEqual([{ id: 1, name: 'Action' }]);
+    expect((service as any).client.get).toHaveBeenCalledWith('/genre/movie/list');
+  });
+
+  it('should get popular movies from TMDB', async () => {
+    (service as any).client.get.mockResolvedValue({
+      data: { results: [{ id: 101, title: 'Movie1' }] },
+    });
+
+    const result = await service.getPopular(1);
+
+    expect(result).toEqual({ results: [{ id: 101, title: 'Movie1' }] });
+    expect((service as any).client.get).toHaveBeenCalledWith('/movie/popular', { params: { page: 1 } });
+  });
+
+  it('should get movie details from TMDB', async () => {
+    (service as any).client.get.mockResolvedValue({
+      data: { id: 101, title: 'Movie1', overview: 'A movie' },
+    });
+
+    const result = await service.getMovieDetails(101);
+
+    expect(result).toEqual({ id: 101, title: 'Movie1', overview: 'A movie' });
+    expect((service as any).client.get).toHaveBeenCalledWith('/movie/101');
+  });
+});


### PR DESCRIPTION
This pull request adds comprehensive unit tests for controllers, services, modules, and repositories across the authentication, movies, genres, lists, ratings, and sync features. The tests use Jest to mock dependencies and verify core behaviors, improving test coverage and reliability for the application's main components.

**Authentication Feature:**
- Added tests for `AuthController` covering registration and login flows, including user validation and token issuance.
- Added tests for `AuthService` to verify user validation, registration, login, and integration with JWT and Prisma.
- Added a basic test for `AuthModule` to ensure module definition.

**Movies Feature:**
- Added tests for `MoviesController` for listing and retrieving movie details.
- Added tests for `MoviesService` to verify caching logic, listing, pagination, and detail retrieval.
- Added a basic test for the `MoviePrismaRepository` constructor.

**Genres Feature:**
- Added tests for `GenresController` to verify genre listing and caching behavior.
- Added a basic test for `GenresModule`.
- Added a basic test for the `GenrePrismaRepository` constructor.

**Lists Feature:**
- Added tests for `ListsController` covering watchlist and favorites endpoints (get, add, remove).
- Added tests for `ListsService` for watchlist and favorites functionality, including interactions with Prisma.
- Added a basic test for `ListsModule`.

**Ratings Feature:**
- Added tests for `RatingsController` to verify movie rating and retrieval endpoints.
- Added tests for `RatingsService` to verify rating logic, aggregate updates, and cache invalidation.
- Added a basic test for `RatingsModule`.
- Added a basic test for the `RatingPrismaRepository` constructor.

**Sync Feature:**
- Added tests for `SyncController` to verify scheduled sync, genre sync, and popular movies sync operations.